### PR TITLE
Update target-lexicon to support loongarch64 architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "unicode-ident"


### PR DESCRIPTION
Hi,

I want to update [target-lexicon to support loongarch64 architecture](https://github.com/bytecodealliance/target-lexicon/commit/35766366e5bbd31ba87281608f1b6366448a24a4).

Thanks,
Leslie Zhai