### PR TITLE
Add pickle support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use pyo3::exceptions::PyIndexError;
 use pyo3::pyclass::CompareOp;
 use pyo3::types::{PyDict, PyIterator, PyTuple, PyType};
 use pyo3::{exceptions::PyKeyError, types::PyMapping};
-use pyo3::{prelude::*, AsPyPointer};
+use pyo3::{prelude::*, AsPyPointer, PyTypeInfo};
 use rpds::{HashTrieMap, HashTrieMapSync, HashTrieSet, HashTrieSetSync, List, ListSync};
 
 #[derive(Clone, Debug)]
@@ -165,6 +165,16 @@ impl HashTrieMapPy {
             .into_py(py)),
             _ => Ok(py.NotImplemented()),
         }
+    }
+
+    fn __reduce__(slf: PyRef<Self>) -> (&PyType, (Vec<(Key, PyObject)>,)) {
+        (
+            HashTrieMapPy::type_object(slf.py()),
+            (slf.inner
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),),
+        )
     }
 
     #[classmethod]
@@ -344,6 +354,13 @@ impl HashTrieSetPy {
             CompareOp::Le => Ok(is_subset(&self.inner, &other.inner).into_py(py)),
             _ => Ok(py.NotImplemented()),
         }
+    }
+
+    fn __reduce__(slf: PyRef<Self>) -> (&PyType, (Vec<Key>,)) {
+        (
+            HashTrieSetPy::type_object(slf.py()),
+            (slf.inner.iter().cloned().collect(),),
+        )
     }
 
     fn insert(&self, value: Key) -> HashTrieSetPy {
@@ -544,6 +561,13 @@ impl ListPy {
         ListPy {
             inner: self.inner.reverse(),
         }
+    }
+
+    fn __reduce__(slf: PyRef<Self>) -> (&PyType, (Vec<PyObject>,)) {
+        (
+            ListPy::type_object(slf.py()),
+            (slf.inner.iter().cloned().collect(),),
+        )
     }
 
     #[getter]

--- a/tests/test_hash_trie_map.py
+++ b/tests/test_hash_trie_map.py
@@ -27,6 +27,7 @@ Pre-modification, these were MIT licensed, and are copyright:
     OTHER DEALINGS IN THE SOFTWARE.
 """
 from collections.abc import Hashable, Mapping
+import pickle
 
 import pytest
 
@@ -322,3 +323,9 @@ def test_more_eq():
     assert HashTrieMap({1: 2}) != HashTrieMap({1: 3})
     assert HashTrieMap({o: 1}) != HashTrieMap({o: o})
     assert HashTrieMap([]) != HashTrieMap([(o, 1)])
+
+
+def test_pickle():
+    assert pickle.loads(pickle.dumps(HashTrieMap([(1, 2), (3, 4)]))) == HashTrieMap(
+        [(1, 2), (3, 4)]
+    )

--- a/tests/test_hash_trie_map.py
+++ b/tests/test_hash_trie_map.py
@@ -326,6 +326,6 @@ def test_more_eq():
 
 
 def test_pickle():
-    assert pickle.loads(pickle.dumps(HashTrieMap([(1, 2), (3, 4)]))) == HashTrieMap(
-        [(1, 2), (3, 4)]
-    )
+    assert pickle.loads(
+        pickle.dumps(HashTrieMap([(1, 2), (3, 4)]))
+    ) == HashTrieMap([(1, 2), (3, 4)])

--- a/tests/test_hash_trie_set.py
+++ b/tests/test_hash_trie_set.py
@@ -26,6 +26,8 @@ Pre-modification, these were MIT licensed, and are copyright:
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     OTHER DEALINGS IN THE SOFTWARE.
 """
+import pickle
+
 import pytest
 
 from rpds import HashTrieSet
@@ -181,3 +183,9 @@ def test_more_set_comparisons():
     assert s <= s
     assert not (s > s)
     assert s >= s
+
+
+def test_pickle():
+    assert pickle.loads(pickle.dumps(HashTrieSet([1, 2, 3, 4]))) == HashTrieSet(
+        [1, 2, 3, 4]
+    )

--- a/tests/test_hash_trie_set.py
+++ b/tests/test_hash_trie_set.py
@@ -186,6 +186,6 @@ def test_more_set_comparisons():
 
 
 def test_pickle():
-    assert pickle.loads(pickle.dumps(HashTrieSet([1, 2, 3, 4]))) == HashTrieSet(
-        [1, 2, 3, 4]
-    )
+    assert pickle.loads(
+        pickle.dumps(HashTrieSet([1, 2, 3, 4]))
+    ) == HashTrieSet([1, 2, 3, 4])

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -26,6 +26,8 @@ Pre-modification, these were MIT licensed, and are copyright:
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     OTHER DEALINGS IN THE SOFTWARE.
 """
+import pickle
+
 import pytest
 
 from rpds import List
@@ -139,3 +141,7 @@ def test_more_eq():
     assert not (List([o, o]) != List([o, o]))
     assert not (List([o]) != List([o]))
     assert not (List() != List([]))
+
+
+def test_pickle():
+    assert pickle.loads(pickle.dumps(List([1, 2, 3, 4]))) == List([1, 2, 3, 4])


### PR DESCRIPTION
This is required to use `rpds` structures with `multiprocessing` and the Django parallel test runner.