### PR TITLE
Configure Black in pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,7 @@ repos:
   - repo: https://github.com/psf/black
     rev: 23.11.0
     hooks:
-      - name: black
-        id: black
-        args: ["--line-length", "79"]
+      - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ Issues = "https://github.com/crate-py/rpds/issues/"
 Funding = "https://github.com/sponsors/Julian"
 Source = "https://github.com/crate-py/rpds"
 
+[tool.black]
+line-length = 79
+
 [tool.isort]
 combine_as_imports = true
 from_first = true


### PR DESCRIPTION
This way Black uses the project’s settings when invoked directly by the user or their editor, and not only via pre-commit.