### PR TITLE
Bump `pyo3` to `0.21.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,15 +14,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cfg-if"
@@ -38,9 +38,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "libc"
@@ -50,9 +50,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -60,24 +60,24 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -104,18 +104,18 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -176,18 +176,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags",
 ]
@@ -212,15 +212,15 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "static_assertions"
@@ -230,9 +230,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -241,21 +241,21 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.9"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "triomphe"
-version = "0.1.9"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unindent"
@@ -265,13 +265,14 @@ checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -280,42 +281,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ rpds = "1.1.0"
 archery = "1.2.0"
 
 [dependencies.pyo3]
-version = "0.20.3"
+version = "0.21.2"
 features = ["extension-module"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 
 use pyo3::exceptions::PyIndexError;
 use pyo3::pyclass::CompareOp;
-use pyo3::types::{PyDict, PyIterator, PyNone, PyTuple, PyType};
+use pyo3::types::{PyDict, PyIterator, PyTuple, PyType};
 use pyo3::{exceptions::PyKeyError, types::PyMapping};
 use pyo3::{prelude::*, AsPyPointer, PyTypeInfo};
 use rpds::{
@@ -48,10 +48,10 @@ unsafe impl AsPyPointer for Key {
 }
 
 impl<'source> FromPyObject<'source> for Key {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
         Ok(Key {
             hash: ob.hash()?,
-            inner: ob.into(),
+            inner: <pyo3::Bound<'_, pyo3::PyAny> as Clone>::clone(ob).unbind(),
         })
     }
 }
@@ -69,7 +69,7 @@ impl From<HashTrieMapSync<Key, PyObject>> for HashTrieMapPy {
 }
 
 impl<'source> FromPyObject<'source> for HashTrieMapPy {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
         let mut ret = HashTrieMap::new_sync();
         if let Ok(mapping) = ob.downcast::<PyMapping>() {
             for each in mapping.items()?.iter()? {
@@ -90,7 +90,7 @@ impl<'source> FromPyObject<'source> for HashTrieMapPy {
 impl HashTrieMapPy {
     #[new]
     #[pyo3(signature = (value=None, **kwds))]
-    fn init(value: Option<HashTrieMapPy>, kwds: Option<&PyDict>) -> PyResult<Self> {
+    fn init(value: Option<HashTrieMapPy>, kwds: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
         let mut map: HashTrieMapPy;
         if let Some(value) = value {
             map = value;
@@ -101,7 +101,7 @@ impl HashTrieMapPy {
         }
         if let Some(kwds) = kwds {
             for (k, v) in kwds {
-                map.inner.insert_mut(Key::extract(k)?, v.into());
+                map.inner.insert_mut(Key::extract_bound(&k)?, v.into());
             }
         }
         Ok(map)
@@ -169,9 +169,9 @@ impl HashTrieMapPy {
         }
     }
 
-    fn __reduce__(slf: PyRef<Self>) -> (&PyType, (Vec<(Key, PyObject)>,)) {
+    fn __reduce__(slf: PyRef<Self>) -> (Bound<'_, PyType>, (Vec<(Key, PyObject)>,)) {
         (
-            HashTrieMapPy::type_object(slf.py()),
+            HashTrieMapPy::type_object_bound(slf.py()),
             (slf.inner
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
@@ -180,27 +180,34 @@ impl HashTrieMapPy {
     }
 
     #[classmethod]
-    fn convert(_cls: &PyType, value: &PyAny, py: Python) -> PyResult<PyObject> {
+    fn convert(
+        _cls: &Bound<'_, PyType>,
+        value: Bound<'_, PyAny>,
+        py: Python,
+    ) -> PyResult<PyObject> {
         if value.is_instance_of::<HashTrieMapPy>() {
-            Ok(value.into())
+            Ok(value.unbind())
         } else {
-            Ok(HashTrieMapPy::extract(value)?.into_py(py))
+            Ok(HashTrieMapPy::extract_bound(&value)?.into_py(py))
         }
     }
 
     #[classmethod]
     fn fromkeys(
-        _cls: &PyType,
-        keys: &PyAny,
-        val: Option<&PyAny>,
+        _cls: &Bound<'_, PyType>,
+        keys: &Bound<'_, PyAny>,
+        val: Option<&Bound<'_, PyAny>>,
         py: Python,
     ) -> PyResult<HashTrieMapPy> {
         let mut inner = HashTrieMap::new_sync();
-        let none = py.None();
-        let value = val.unwrap_or_else(|| none.as_ref(py));
+        let none = py.None().into_bound(py);
+        let value = val.unwrap_or(&none);
         for each in keys.iter()? {
-            let key = Key::extract(each?)?.to_owned();
-            inner.insert_mut(key, value.into());
+            let key = Key::extract_bound(&each?)?.to_owned();
+            inner.insert_mut(
+                key,
+                <pyo3::Bound<'_, pyo3::PyAny> as Clone>::clone(value).unbind(),
+            );
         }
         Ok(HashTrieMapPy { inner })
     }
@@ -242,9 +249,9 @@ impl HashTrieMapPy {
         }
     }
 
-    fn insert(&self, key: Key, value: &PyAny) -> HashTrieMapPy {
+    fn insert(&self, key: Key, value: Bound<'_, PyAny>) -> HashTrieMapPy {
         HashTrieMapPy {
-            inner: self.inner.insert(key, value.into()),
+            inner: self.inner.insert(key, value.unbind()),
         }
     }
 
@@ -258,17 +265,21 @@ impl HashTrieMapPy {
     }
 
     #[pyo3(signature = (*maps, **kwds))]
-    fn update(&self, maps: &PyTuple, kwds: Option<&PyDict>) -> PyResult<HashTrieMapPy> {
+    fn update(
+        &self,
+        maps: &Bound<'_, PyTuple>,
+        kwds: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<HashTrieMapPy> {
         let mut inner = self.inner.clone();
         for value in maps {
-            let map = HashTrieMapPy::extract(value)?;
+            let map = HashTrieMapPy::extract_bound(&value)?;
             for (k, v) in &map.inner {
                 inner.insert_mut(k.to_owned(), v.to_owned());
             }
         }
         if let Some(kwds) = kwds {
             for (k, v) in kwds {
-                inner.insert_mut(Key::extract(k)?, v.extract()?);
+                inner.insert_mut(Key::extract_bound(&k)?, v.extract()?);
             }
         }
         Ok(HashTrieMapPy { inner })
@@ -343,22 +354,22 @@ impl KeysView {
         self.inner.contains_key(&key)
     }
 
-    fn __eq__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? != slf.inner.size() {
+    fn __eq__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? != slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
-            if !slf.inner.contains_key(&Key::extract(each?)?) {
+            if !slf.inner.contains_key(&Key::extract_bound(&each?)?) {
                 return Ok(false);
             }
         }
         Ok(true)
     }
 
-    fn __lt__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? <= slf.inner.size() {
+    fn __lt__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? <= slf.inner.size() {
             return Ok(false);
         }
         for each in slf.inner.keys() {
@@ -369,9 +380,9 @@ impl KeysView {
         Ok(true)
     }
 
-    fn __le__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? < slf.inner.size() {
+    fn __le__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? < slf.inner.size() {
             return Ok(false);
         }
         for each in slf.inner.keys() {
@@ -382,26 +393,26 @@ impl KeysView {
         Ok(true)
     }
 
-    fn __gt__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? >= slf.inner.size() {
+    fn __gt__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? >= slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
-            if !slf.inner.contains_key(&Key::extract(each?)?) {
+            if !slf.inner.contains_key(&Key::extract_bound(&each?)?) {
                 return Ok(false);
             }
         }
         Ok(true)
     }
 
-    fn __ge__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? > slf.inner.size() {
+    fn __ge__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? > slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
-            if !slf.inner.contains_key(&Key::extract(each?)?) {
+            if !slf.inner.contains_key(&Key::extract_bound(&each?)?) {
                 return Ok(false);
             }
         }
@@ -418,11 +429,11 @@ impl KeysView {
         slf.inner.size()
     }
 
-    fn __and__(slf: PyRef<'_, Self>, other: &PyAny) -> PyResult<HashTrieSetPy> {
+    fn __and__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>) -> PyResult<HashTrieSetPy> {
         KeysView::intersection(slf, other)
     }
 
-    fn __or__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<KeysView> {
+    fn __or__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<KeysView> {
         KeysView::union(slf, other, py)
     }
 
@@ -438,11 +449,11 @@ impl KeysView {
         format!("keys_view({{{}}})", contents.collect::<Vec<_>>().join(", "))
     }
 
-    fn intersection(slf: PyRef<'_, Self>, other: &PyAny) -> PyResult<HashTrieSetPy> {
+    fn intersection(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>) -> PyResult<HashTrieSetPy> {
         // TODO: iterate over the shorter one if it's got a length
         let mut inner = HashTrieSet::new_sync();
         for each in other.iter()? {
-            let key = Key::extract(each?)?;
+            let key = Key::extract_bound(&each?)?;
             if slf.inner.contains_key(&key) {
                 inner.insert_mut(key);
             }
@@ -450,13 +461,12 @@ impl KeysView {
         Ok(HashTrieSetPy { inner })
     }
 
-    fn union(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<KeysView> {
+    fn union(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<KeysView> {
         // There doesn't seem to be a low-effort way to get a HashTrieSet out of a map,
         // so we just keep our map and add values we'll ignore.
         let mut inner = slf.inner.clone();
-        let none = PyNone::get(py);
         for each in other.iter()? {
-            inner.insert_mut(Key::extract(each?)?, none.into());
+            inner.insert_mut(Key::extract_bound(&each?)?, py.None());
         }
         Ok(KeysView { inner })
     }
@@ -514,9 +524,9 @@ impl ItemsView {
         slf.inner.size()
     }
 
-    fn __eq__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? != slf.inner.size() {
+    fn __eq__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? != slf.inner.size() {
             return Ok(false);
         }
         for (k, v) in slf.inner.iter() {
@@ -529,19 +539,19 @@ impl ItemsView {
 
     fn __repr__(&self, py: Python) -> String {
         let contents = self.inner.into_iter().map(|(k, v)| {
-            let tuple = PyTuple::new(py, [k.inner.to_owned(), v.to_owned()]);
+            let tuple = PyTuple::new_bound(py, [k.inner.to_owned(), v.to_owned()]);
             format!("{:?}", tuple)
         });
         format!("items_view([{}])", contents.collect::<Vec<_>>().join(", "))
     }
 
-    fn __lt__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? <= slf.inner.size() {
+    fn __lt__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? <= slf.inner.size() {
             return Ok(false);
         }
         for (k, v) in slf.inner.iter() {
-            let pair = PyTuple::new(py, [k.inner.to_owned(), v.to_owned()]);
+            let pair = PyTuple::new_bound(py, [k.inner.to_owned(), v.to_owned()]);
             // FIXME: needs to compare
             if !other.contains(pair)? {
                 return Ok(false);
@@ -550,13 +560,13 @@ impl ItemsView {
         Ok(true)
     }
 
-    fn __le__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? < slf.inner.size() {
+    fn __le__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? < slf.inner.size() {
             return Ok(false);
         }
         for (k, v) in slf.inner.iter() {
-            let pair = PyTuple::new(py, [k.inner.to_owned(), v.to_owned()]);
+            let pair = PyTuple::new_bound(py, [k.inner.to_owned(), v.to_owned()]);
             // FIXME: needs to compare
             if !other.contains(pair)? {
                 return Ok(false);
@@ -565,17 +575,20 @@ impl ItemsView {
         Ok(true)
     }
 
-    fn __gt__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? >= slf.inner.size() {
+    fn __gt__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? >= slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
             let kv = each?;
             let k = kv.get_item(0)?;
-            match slf.inner.get(&Key::extract(k)?) {
+            match slf.inner.get(&Key::extract_bound(&k)?) {
                 Some(value) => {
-                    let pair = PyTuple::new(py, [k, value.as_ref(py)]);
+                    let pair = PyTuple::new_bound(
+                        py,
+                        [k, <Py<pyo3::PyAny> as Clone>::clone(value).into_bound(py)],
+                    );
                     if !pair.eq(kv)? {
                         return Ok(false);
                     }
@@ -586,17 +599,23 @@ impl ItemsView {
         Ok(true)
     }
 
-    fn __ge__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? > slf.inner.size() {
+    fn __ge__(slf: PyRef<'_, Self>, other: &Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? > slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
             let kv = each?;
             let k = kv.get_item(0)?;
-            match slf.inner.get(&Key::extract(k)?) {
+            match slf.inner.get(&Key::extract_bound(&k)?) {
                 Some(value) => {
-                    let pair = PyTuple::new(py, [k, value.as_ref(py)]);
+                    let pair = PyTuple::new_bound(
+                        py,
+                        [
+                            k,
+                            <pyo3::Py<pyo3::PyAny> as Clone>::clone(value).into_bound(py),
+                        ],
+                    );
                     if !pair.eq(kv)? {
                         return Ok(false);
                     }
@@ -607,39 +626,61 @@ impl ItemsView {
         Ok(true)
     }
 
-    fn __and__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<HashTrieSetPy> {
+    fn __and__(
+        slf: PyRef<'_, Self>,
+        other: &Bound<'_, PyAny>,
+        py: Python,
+    ) -> PyResult<HashTrieSetPy> {
         ItemsView::intersection(slf, other, py)
     }
 
-    fn __or__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<HashTrieSetPy> {
+    fn __or__(
+        slf: PyRef<'_, Self>,
+        other: &Bound<'_, PyAny>,
+        py: Python,
+    ) -> PyResult<HashTrieSetPy> {
         ItemsView::union(slf, other, py)
     }
 
-    fn intersection(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<HashTrieSetPy> {
+    fn intersection(
+        slf: PyRef<'_, Self>,
+        other: &Bound<'_, PyAny>,
+        py: Python,
+    ) -> PyResult<HashTrieSetPy> {
         // TODO: iterate over the shorter one if it's got a length
         let mut inner = HashTrieSet::new_sync();
         for each in other.iter()? {
             let kv = each?;
             let k = kv.get_item(0)?;
-            if let Some(value) = slf.inner.get(&Key::extract(k)?) {
-                let pair = PyTuple::new(py, [k, value.as_ref(py)]);
+            if let Some(value) = slf.inner.get(&Key::extract_bound(&k)?) {
+                let pair = PyTuple::new_bound(
+                    py,
+                    [
+                        k,
+                        <pyo3::Py<pyo3::PyAny> as Clone>::clone(value).into_bound(py),
+                    ],
+                );
                 if pair.eq(kv)? {
-                    inner.insert_mut(Key::extract(pair)?);
+                    inner.insert_mut(Key::extract_bound(&pair)?);
                 }
             }
         }
         Ok(HashTrieSetPy { inner })
     }
 
-    fn union(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<HashTrieSetPy> {
+    fn union(
+        slf: PyRef<'_, Self>,
+        other: &Bound<'_, PyAny>,
+        py: Python,
+    ) -> PyResult<HashTrieSetPy> {
         // TODO: this is very inefficient, but again can't seem to get a HashTrieSet out of ourself
         let mut inner = HashTrieSet::new_sync();
         for (k, v) in slf.inner.iter() {
-            let pair = PyTuple::new(py, [k.inner.to_owned(), v.to_owned()]);
-            inner.insert_mut(Key::extract(pair)?);
+            let pair = PyTuple::new_bound(py, [k.inner.to_owned(), v.to_owned()]);
+            inner.insert_mut(Key::extract_bound(&pair)?);
         }
         for each in other.iter()? {
-            inner.insert_mut(Key::extract(each?)?);
+            inner.insert_mut(Key::extract_bound(&each?)?);
         }
         Ok(HashTrieSetPy { inner })
     }
@@ -652,7 +693,7 @@ struct HashTrieSetPy {
 }
 
 impl<'source> FromPyObject<'source> for HashTrieSetPy {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
         let mut ret = HashTrieSet::new_sync();
         for each in ob.iter()? {
             let k: Key = each?.extract()?;
@@ -719,22 +760,22 @@ impl HashTrieSetPy {
         )
     }
 
-    fn __eq__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? != slf.inner.size() {
+    fn __eq__(slf: PyRef<'_, Self>, other: Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? != slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
-            if !slf.inner.contains(&Key::extract(each?)?) {
+            if !slf.inner.contains(&Key::extract_bound(&each?)?) {
                 return Ok(false);
             }
         }
         Ok(true)
     }
 
-    fn __lt__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? <= slf.inner.size() {
+    fn __lt__(slf: PyRef<'_, Self>, other: Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? <= slf.inner.size() {
             return Ok(false);
         }
         for each in slf.inner.iter() {
@@ -745,9 +786,9 @@ impl HashTrieSetPy {
         Ok(true)
     }
 
-    fn __le__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? < slf.inner.size() {
+    fn __le__(slf: PyRef<'_, Self>, other: Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? < slf.inner.size() {
             return Ok(false);
         }
         for each in slf.inner.iter() {
@@ -758,35 +799,35 @@ impl HashTrieSetPy {
         Ok(true)
     }
 
-    fn __gt__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? >= slf.inner.size() {
+    fn __gt__(slf: PyRef<'_, Self>, other: Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? >= slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
-            if !slf.inner.contains(&Key::extract(each?)?) {
+            if !slf.inner.contains(&Key::extract_bound(&each?)?) {
                 return Ok(false);
             }
         }
         Ok(true)
     }
 
-    fn __ge__(slf: PyRef<'_, Self>, other: &PyAny, py: Python) -> PyResult<bool> {
-        let abc = PyModule::import(py, "collections.abc")?;
-        if !other.is_instance(abc.getattr("Set")?)? || other.len()? > slf.inner.size() {
+    fn __ge__(slf: PyRef<'_, Self>, other: Bound<'_, PyAny>, py: Python) -> PyResult<bool> {
+        let abc = PyModule::import_bound(py, "collections.abc")?;
+        if !other.is_instance(&abc.getattr("Set")?)? || other.len()? > slf.inner.size() {
             return Ok(false);
         }
         for each in other.iter()? {
-            if !slf.inner.contains(&Key::extract(each?)?) {
+            if !slf.inner.contains(&Key::extract_bound(&each?)?) {
                 return Ok(false);
             }
         }
         Ok(true)
     }
 
-    fn __reduce__(slf: PyRef<Self>) -> (&PyType, (Vec<Key>,)) {
+    fn __reduce__(slf: PyRef<Self>) -> (Bound<'_, PyType>, (Vec<Key>,)) {
         (
-            HashTrieSetPy::type_object(slf.py()),
+            HashTrieSetPy::type_object_bound(slf.py()),
             (slf.inner.iter().cloned().collect(),),
         )
     }
@@ -881,12 +922,12 @@ impl HashTrieSetPy {
     }
 
     #[pyo3(signature = (*iterables))]
-    fn update(&self, iterables: &PyTuple) -> PyResult<HashTrieSetPy> {
+    fn update(&self, iterables: Bound<'_, PyTuple>) -> PyResult<HashTrieSetPy> {
         let mut inner = self.inner.clone();
         for each in iterables {
             let iter = each.iter()?;
             for value in iter {
-                inner.insert_mut(Key::extract(value?)?.to_owned());
+                inner.insert_mut(Key::extract_bound(&value?)?.to_owned());
             }
         }
         Ok(HashTrieSetPy { inner })
@@ -924,10 +965,10 @@ impl From<ListSync<PyObject>> for ListPy {
 }
 
 impl<'source> FromPyObject<'source> for ListPy {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
         let mut ret = List::new_sync();
-        let reversed = PyModule::import(ob.py(), "builtins")?.getattr("reversed")?;
-        let rob: &PyIterator = reversed.call1((ob,))?.iter()?;
+        let reversed = PyModule::import_bound(ob.py(), "builtins")?.getattr("reversed")?;
+        let rob: Bound<'_, PyIterator> = reversed.call1((ob,))?.iter()?;
         for each in rob {
             ret.push_front_mut(each?.extract()?);
         }
@@ -939,7 +980,7 @@ impl<'source> FromPyObject<'source> for ListPy {
 impl ListPy {
     #[new]
     #[pyo3(signature = (*elements))]
-    fn init(elements: &PyTuple) -> PyResult<Self> {
+    fn init(elements: &Bound<'_, PyTuple>) -> PyResult<Self> {
         let mut ret: ListPy;
         if elements.len() == 1 {
             ret = elements.get_item(0)?.extract()?;
@@ -1005,9 +1046,9 @@ impl ListPy {
         }
     }
 
-    fn __reduce__(slf: PyRef<Self>) -> (&PyType, (Vec<PyObject>,)) {
+    fn __reduce__(slf: PyRef<Self>) -> (Bound<'_, PyType>, (Vec<PyObject>,)) {
         (
-            ListPy::type_object(slf.py()),
+            ListPy::type_object_bound(slf.py()),
             (slf.inner.iter().cloned().collect(),),
         )
     }
@@ -1090,7 +1131,7 @@ impl From<QueueSync<PyObject>> for QueuePy {
 }
 
 impl<'source> FromPyObject<'source> for QueuePy {
-    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
         let mut ret = Queue::new_sync();
         for each in ob.iter()? {
             ret.enqueue_mut(each?.extract()?);
@@ -1103,7 +1144,7 @@ impl<'source> FromPyObject<'source> for QueuePy {
 impl QueuePy {
     #[new]
     #[pyo3(signature = (*elements))]
-    fn init(elements: &PyTuple, py: Python<'_>) -> PyResult<Self> {
+    fn init(elements: &Bound<'_, PyTuple>, py: Python<'_>) -> PyResult<Self> {
         let mut ret: QueuePy;
         if elements.len() == 1 {
             ret = elements.get_item(0)?.extract()?;
@@ -1131,7 +1172,7 @@ impl QueuePy {
     }
 
     fn __hash__(&self, py: Python<'_>) -> PyResult<u64> {
-        let hash = PyModule::import(py, "builtins")?.getattr("hash")?;
+        let hash = PyModule::import_bound(py, "builtins")?.getattr("hash")?;
         let mut hasher = DefaultHasher::new();
         for each in &self.inner {
             let n: i64 = hash.call1((each.into_py(py),))?.extract()?;
@@ -1185,7 +1226,7 @@ impl QueuePy {
         self.inner.is_empty()
     }
 
-    fn enqueue(&self, value: &PyAny) -> Self {
+    fn enqueue(&self, value: Bound<'_, PyAny>) -> Self {
         QueuePy {
             inner: self.inner.enqueue(value.into()),
         }
@@ -1202,7 +1243,7 @@ impl QueuePy {
 
 #[pymodule]
 #[pyo3(name = "rpds")]
-fn rpds_py(py: Python, m: &PyModule) -> PyResult<()> {
+fn rpds_py(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<HashTrieMapPy>()?;
     m.add_class::<HashTrieSetPy>()?;
     m.add_class::<ListPy>()?;
@@ -1210,24 +1251,24 @@ fn rpds_py(py: Python, m: &PyModule) -> PyResult<()> {
 
     PyMapping::register::<HashTrieMapPy>(py)?;
 
-    let abc = PyModule::import(py, "collections.abc")?;
+    let abc = PyModule::import_bound(py, "collections.abc")?;
 
     abc.getattr("Set")?
-        .call_method1("register", (HashTrieSetPy::type_object(py),))?;
+        .call_method1("register", (HashTrieSetPy::type_object_bound(py),))?;
 
     abc.getattr("MappingView")?
-        .call_method1("register", (KeysView::type_object(py),))?;
+        .call_method1("register", (KeysView::type_object_bound(py),))?;
     abc.getattr("MappingView")?
-        .call_method1("register", (ValuesView::type_object(py),))?;
+        .call_method1("register", (ValuesView::type_object_bound(py),))?;
     abc.getattr("MappingView")?
-        .call_method1("register", (ItemsView::type_object(py),))?;
+        .call_method1("register", (ItemsView::type_object_bound(py),))?;
 
     abc.getattr("KeysView")?
-        .call_method1("register", (KeysView::type_object(py),))?;
+        .call_method1("register", (KeysView::type_object_bound(py),))?;
     abc.getattr("ValuesView")?
-        .call_method1("register", (ValuesView::type_object(py),))?;
+        .call_method1("register", (ValuesView::type_object_bound(py),))?;
     abc.getattr("ItemsView")?
-        .call_method1("register", (ItemsView::type_object(py),))?;
+        .call_method1("register", (ItemsView::type_object_bound(py),))?;
 
     Ok(())
 }


### PR DESCRIPTION
<blockquote>

Code will need to add the occasional & to borrow the new smart pointer as `&Bound<T>` to pass these types around (or use `.clone()` at the very small cost of increasing the Python reference count)

</blockquote>

https://pyo3.rs/v0.21.0/migration.html