### PR TITLE
Make Python versions in GitHub Actions consistent

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,7 @@ jobs:
             3.11
             3.12
             3.13
+            pypy3.9
             pypy3.10
           allow-prereleases: true
       - name: Set up uv
@@ -76,12 +77,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            pypy3.9
+            pypy3.10
+          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9 pypy3.10'
+          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10'
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -103,12 +113,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            pypy3.9
+            pypy3.10
+          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9 pypy3.10'
+          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10'
           manylinux: musllinux_1_2
           sccache: "true"
       - name: Upload wheels
@@ -122,7 +141,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        target: [x64, x86]
+        target: [x64, x86] # x86 is not supported by pypy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -133,12 +152,16 @@ jobs:
             3.10
             3.11
             3.12
+            3.13
+            ${{ matrix.target == 'x64' && 'pypy3.9' || '' }}
+            ${{ matrix.target == 'x64' && 'pypy3.10' || '' }}
+          allow-prereleases: true
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12'
+          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13' --interpreter ${{ matrix.target == 'x64' && 'pypy3.9 pypy3.10' || '' }}
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -156,12 +179,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            pypy3.9
+            pypy3.10
+          allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 pypy3.8 pypy3.9 pypy3.10'
+          args: --release --out dist --interpreter '3.8 3.9 3.10 3.11 3.12 3.13 pypy3.9 pypy3.10'
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -174,6 +206,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            pypy3.9
+            pypy3.10
+          allow-prereleases: true
       - name: Build an sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "cc"
+version = "1.0.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7879eb018ac754bba32cb0eec7526391c02c14a093121857ed09fbf1d1057d41"
 dependencies = [
  "once_cell",
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -133,6 +140,15 @@ dependencies = [
  "pyo3-build-config",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0b78171a90d808b319acfad166c4790d9e9759bbc14ac8273fe133673dd41b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,6 @@ archery = "1.2.0"
 
 [dependencies.pyo3]
 version = "0.22.1"
-features = ["extension-module"]
+# To build extension for PyPy on Windows, "generate-import-lib" is needed:
+# https://github.com/PyO3/maturin-action/issues/267#issuecomment-2106844429
+features = ["extension-module", "generate-import-lib"]


### PR DESCRIPTION
To ensure consistently, use the following Python versions everywhere in CI:
- 3.8
- 3.9
- 3.10
- 3.11
- 3.12
- 3.13
- pypy3.9
- pypy3.10

The wheels for Python 3.13 are beneficial for dependent packages such as `jsonschema`.

Note that PyPy3.8 was dropped since the PyPy website (https://www.pypy.org/) states they currently support Python versions 3.10, 3.9, and 2.7.

To build the extension for PyPy on Windows, `"generate-import-lib"` in `Cargo.toml` is needed, as per this GitHub issue:
https://github.com/PyO3/maturin-action/issues/267#issuecomment-2106844429
