### PR TITLE
update license file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 requires-python = ">=3.9"
 readme = "README.rst"
 license = "MIT"
-license-files = ["COPYING"]
+license-files = ["LICENSE"]
 keywords = ["data structures", "rust", "persistent"]
 authors = [
   { name = "Julian Berman", email = "Julian+rpds@GrayVines.com" },


### PR DESCRIPTION
Congratulations on 0.23.0! :tada:

While working this downstream on [conda-forge](https://github.com/conda-forge/rpds-py-feedstock/pull/39), noted that the `pyproject.toml` references `COPYING` as the `license-file`, but the repo's file is `LICENSE`. This PR updates it to align with the file that exists.

A broader note, related to #88: has the `abi3` route been considered for this package? While I'm not qualified to assess whether this would be a good thing from a performance perspective, much less propose the changes, as a repackager, this would slash the number of CPython builds by a large margin. PyPy and 3.13t would no doubt need special consideration.