### PR TITLE
replace quansight-labs/setup-python with actions/setup-python

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
         run: brew install enchant
         if: runner.os == 'macOS' && startsWith(matrix.noxenv, 'docs')
       - name: Set up Python
-        uses: quansight-labs/setup-python@v5
+        uses: actions/setup-python@v5
         with:
           python-version: |
             3.9
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: quansight-labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: |
             3.9
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: quansight-labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: |
             3.9
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: quansight-labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: |
             3.9
@@ -178,6 +178,8 @@ jobs:
           name: dist-${{ github.job }}-${{ matrix.target }}
           path: dist
 
+  # free-threaded and normal builds share a site-packages folder on Windows so
+  # we must build free-threaded separately
   windows-free-threaded:
     needs: test
     runs-on: windows-latest
@@ -188,7 +190,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: quansight-labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.13t
           allow-prereleases: true
@@ -215,7 +217,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: quansight-labs/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: |
             3.9


### PR DESCRIPTION
The changes in the fork were upstreamed and released in 5.5.0. See https://github.com/actions/setup-python/releases/tag/v5.5.0.