### PR TITLE
Allow packaging of wheels for riscv64 architecture

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,7 +108,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'
           sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
-          manylinux: auto
+          manylinux: manylinux_2_39
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
-        uses: ffgan/maturin-action@910dbe8175fd9ceb6f8b218cfb719213cf23a2a2 # v1.49.3
+        uses: ffgan/maturin-action@d94f64f81b4746a9dd73da3181f7f4b61968e8b9 # v1.49.3
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
-        uses: ffgan/maturin-action@d94f64f81b4746a9dd73da3181f7f4b61968e8b9 # v1.49.3
+        uses: ffgan/maturin-action@542101dd78ba7e859666722008d1e6e9a0ccabb4 # v1.49.3
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
-        uses: PyO3/maturin-action@e10f6c464b90acceb5f640d31beda6d586ba7b4a # v1.49.3
+        uses: PyO3/maturin-action@910dbe8175fd9ceb6f8b218cfb719213cf23a2a2 # v1.49.3
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
             pypy3.11
           allow-prereleases: true
       - name: Build wheels
-        uses: PyO3/maturin-action@910dbe8175fd9ceb6f8b218cfb719213cf23a2a2 # v1.49.3
+        uses: ffgan/maturin-action@910dbe8175fd9ceb6f8b218cfb719213cf23a2a2 # v1.49.3
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le, riscv64gc-unknown-linux-gnu]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For manylinux (gnu/glibc, not musl), after testing, it is possible to package a wheel for the riscv64 architecture. After testing with the riscv64 virtual machine, the test result is passed.

Here is the CI Result, https://github.com/ffgan/rpds/actions/runs/16413208054

The following is the test script and the output of the test script run


### 1. test script

The test script runs on ubuntu22 riscv64.

(u22 rv64 can be used through the qemu virtual machine, [reference link](https://discourse.ubuntu.com/t/ubuntu-installation-on-a-risc-v-virtual-machine-using-a-server-install-image-and-qemu/27636))
```shell
#! /bin/bash
set -e

uname -m
uname -a


git clone https://github.com/ffgan/rpds.git

# this file is not in rpds,please put it in rpds.
# you can get it from this link, https://github.com/ffgan/rpds/actions/runs/16413208054 , Scroll down the page, see  Artifacts
cp dist-manylinux-riscv64gc-unknown-linux-gnu.zip rpds/dist-manylinux-riscv64gc-unknown-linux-gnu.zip
cd rpds
unzip dist-manylinux-riscv64gc-unknown-linux-gnu.zip -d .


python3 --version
python3 -m venv venv
source ./venv/bin/activate


pip install --upgrade pip

pip install rpds_py-0.26.0-cp310-cp310-manylinux_2_31_riscv64.whl


# please make sure you already install uv global
uvx nox --list-sessions --json | jq '[.[].session]'

uvx nox -s "tests-3.10" --

```

### 2. test output

```shell
root@u22:~/new_ceph/rpds# ./test_rpds_riscv.sh
riscv64
Linux u22 6.8.0-64-generic #67~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Jul  3 01:39:30 UTC 2 riscv64 riscv64 riscv64 GNU/Linux
Cloning into 'rpds'...
remote: Enumerating objects: 1686, done.
remote: Counting objects: 100% (482/482), done.
remote: Compressing objects: 100% (134/134), done.
remote: Total 1686 (delta 412), reused 352 (delta 348), pack-reused 1204 (from 2)
Receiving objects: 100% (1686/1686), 356.00 KiB | 433.00 KiB/s, done.
Resolving deltas: 100% (1019/1019), done.
Archive:  dist-manylinux-riscv64gc-unknown-linux-gnu.zip
  inflating: ./rpds_py-0.26.0-cp310-cp310-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp312-cp312-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp311-cp311-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp313-cp313-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp313-cp313t-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp314-cp314-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp314-cp314t-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-cp39-cp39-manylinux_2_31_riscv64.whl
  inflating: ./rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_31_riscv64.whl
  "tests-3.14t",
  "audit",
  "build",
  "style",
  "typing",
  "docs(dirhtml)",
  "docs(doctest)",
  "docs(linkcheck)",
  "docs(man)",
  "docs(spelling)",
  "docs(style)"
]
nox > Running session tests-3.10
nox > Creating virtual environment (uv) using python3.10 in .nox/tests-3-10
nox > /root/.local/bin/uv pip install --config-settings build-args=--profile=dev --no-cache -r /root/new_ceph/rpds/rpds/tests/requirements.txt
nox > pytest --parallel-threads=10 /root/new_ceph/rpds/rpds/tests
================================================= test session starts =================================================
platform linux -- Python 3.10.12, pytest-8.4.1, pluggy-1.6.0
rootdir: /root/new_ceph/rpds/rpds
configfile: pyproject.toml
plugins: run-parallel-0.4.4
collected 116 items
Collected 116 items to run in parallel

tests/test_hash_trie_map.py ···························································                         [ 50%]
tests/test_hash_trie_set.py ·····················                                                               [ 68%]
tests/test_list.py ···················                                                                          [ 85%]
tests/test_queue.py ·················                                                                           [100%]

********************************************* pytest-run-parallel report **********************************************
All tests were run in parallel! 🎉
=========================================== 116 passed in 136.95s (0:02:16) ===========================================
nox > Session tests-3.10 was successful.

```


Therefore, for manylinux, it is possible to package a wheel for riscv64. However, for Linux using musl, after preliminary testing, I have not yet obtained satisfactory results. I will submit a new PR if there are new results later.


Co-authored-by: <nijincheng@iscas.ac.cn>；