### PR TITLE
Allow packaging of wheels for riscv64 architecture

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le, riscv64gc-unknown-linux-gnu]
+        target:
+          [
+            x86_64,
+            x86,
+            aarch64,
+            armv7,
+            s390x,
+            ppc64le,
+            riscv64gc-unknown-linux-gnu,
+          ]
 
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +123,6 @@ jobs:
         with:
           name: dist-${{ github.job }}-${{ matrix.target }}
           path: dist
-
 
   musllinux:
     needs: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le, riscv64gc-unknown-linux-gnu]
 
     steps:
       - uses: actions/checkout@v4
@@ -115,46 +115,6 @@ jobs:
           name: dist-${{ github.job }}-${{ matrix.target }}
           path: dist
 
-  manylinux-riscv64:
-    needs: test
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [riscv64gc-unknown-linux-gnu]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: |
-            3.9
-            3.10
-            3.11
-            3.12
-            3.13
-            3.13t
-            3.14
-            3.14t
-            pypy3.9
-            pypy3.10
-            pypy3.11
-          allow-prereleases: true
-      - name: Build wheels
-        uses: ffgan/maturin-action@542101dd78ba7e859666722008d1e6e9a0ccabb4
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'
-          sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
-          manylinux: manylinux_2_39
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-${{ github.job }}-${{ matrix.target }}
-          path: dist
 
   musllinux:
     needs: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,6 +115,47 @@ jobs:
           name: dist-${{ github.job }}-${{ matrix.target }}
           path: dist
 
+  manylinux-riscv64:
+    needs: test
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [riscv64gc-unknown-linux-gnu]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.9
+            3.10
+            3.11
+            3.12
+            3.13
+            3.13t
+            3.14
+            3.14t
+            pypy3.9
+            pypy3.10
+            pypy3.11
+          allow-prereleases: true
+      - name: Build wheels
+        uses: ffgan/maturin-action@542101dd78ba7e859666722008d1e6e9a0ccabb4
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.9 pypy3.10 pypy3.11'
+          sccache: ${{ github.ref_type != 'tag' }} # zizmor: ignore[cache-poisoning]
+          manylinux: manylinux_2_39
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.job }}-${{ matrix.target }}
+          path: dist
+
   musllinux:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
The issue mentioned in #147 about uploading to test.pypi.org has been resolved

Now pypi already supports uploading pypi packages for riscv64 architecture, for details, please see https://github.com/pypi/warehouse/pull/18390

Here is the link I just uploaded to test.pypi.org https://test.pypi.org/project/rpds-py/0.26.0/#files
(the version in testpypi is manylinux_2_31,which is fine to upload to pypi,not just manylinux_2_39.)

**(I made a mistake before, thinking that pypi can only upload manylinux_2_39 and above packages, in fact, it is not, riscv64 manylinux should support all)**

These whl files come from the [CI link](https://github.com/ffgan/rpds/actions/runs/16769980160) here. the riscv64 zip,[link](https://github.com/ffgan/rpds/actions/runs/16769980160/artifacts/3698114813)

For detailed packaging methods, please see this [link](https://github.com/ffgan/rpds/actions/runs/16769980160/job/47482947641)

I test on ubuntu 24.04 and ubuntu 22.04 riscv
The following is the test script and output

```shell
#! /bin/bash
set -e

uname -m
uname -a

cat /etc/os-release


rm -rf rpds

git clone https://github.com/ffgan/rpds.git

cd rpds

git checkout feature/allow_riscv_package

python3 --version
python3 -m venv venv
source ./venv/bin/activate

pip install --upgrade pip

pip install -i https://test.pypi.org/simple/ rpds-py==0.26.0

# please make sure you already installed uv global
uvx nox --list-sessions --json | jq '[.[].session]'

uvx nox -s "tests-$(python3 --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1,2)" --
```

## ubuntu 24 riscv result 
```shell
(venv) root@45be435d7e5d:~/venv# ./test.sh
riscv64
Linux 45be435d7e5d 6.8.0-71-generic #71~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jul 29 11:14:09 UTC 2 riscv64 riscv64 riscv64 GNU/Linux
PRETTY_NAME="Ubuntu 24.04.2 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.2 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
Cloning into 'rpds'...
remote: Enumerating objects: 1723, done.
remote: Counting objects: 100% (487/487), done.
remote: Compressing objects: 100% (120/120), done.
remote: Total 1723 (delta 427), reused 377 (delta 367), pack-reused 1236 (from 3)
Receiving objects: 100% (1723/1723), 364.10 KiB | 1.48 MiB/s, done.
Resolving deltas: 100% (1039/1039), done.
branch 'feature/allow_riscv_package' set up to track 'origin/feature/allow_riscv_package'.
Switched to a new branch 'feature/allow_riscv_package'
Python 3.12.3
Requirement already satisfied: pip in ./venv/lib/python3.12/site-packages (24.0)
Collecting pip
  Using cached pip-25.2-py3-none-any.whl.metadata (4.7 kB)
Using cached pip-25.2-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.0
    Uninstalling pip-24.0:
      Successfully uninstalled pip-24.0
Successfully installed pip-25.2
Looking in indexes: https://test.pypi.org/simple/
Collecting rpds-py==0.26.0
  Using cached https://test-files.pythonhosted.org/packages/0a/dc/2a78b2aab6f0ef035d04e9bb30fc5e4122ab390ef096a41459fe66673189/rpds_py-0.26.0-cp312-cp312-manylinux_2_31_riscv64.whl.metadata (4.2 kB)
Using cached https://test-files.pythonhosted.org/packages/0a/dc/2a78b2aab6f0ef035d04e9bb30fc5e4122ab390ef096a41459fe66673189/rpds_py-0.26.0-cp312-cp312-manylinux_2_31_riscv64.whl (405 kB)
Installing collected packages: rpds-py
Successfully installed rpds-py-0.26.0
[
  "tests-3.9",
  "tests-3.10",
  "tests-pypy3.10",
  "tests-3.11",
  "tests-pypy3.11",
  "tests-3.12",
  "tests-3.13",
  "tests-3.13t",
  "tests-3.14",
  "tests-3.14t",
  "audit",
  "build",
  "style",
  "typing",
  "docs(dirhtml)",
  "docs(doctest)",
  "docs(linkcheck)",
  "docs(man)",
  "docs(spelling)",
  "docs(style)"
]
nox > Running session tests-3.12
nox > Creating virtual environment (uv) using python3.12 in .nox/tests-3-12
nox > /root/venv/bin/uv pip install --config-settings build-args=--profile=dev --no-cache -r /root/venv/rpds/tests/requirements.txt
nox > pytest --parallel-threads=10 /root/venv/rpds/tests
================================================= test session starts ==================================================
platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
rootdir: /root/venv/rpds
configfile: pyproject.toml
plugins: run-parallel-0.4.4
collected 116 items
Collected 116 items to run in parallel

tests/test_hash_trie_map.py ···························································                          [ 50%]
tests/test_hash_trie_set.py ·····················                                                                [ 68%]
tests/test_list.py ···················                                                                           [ 85%]
tests/test_queue.py ·················                                                                            [100%]

********************************************** pytest-run-parallel report **********************************************
All tests were run in parallel! 🎉
================================================= 116 passed in 24.11s =================================================
nox > Session tests-3.12 was successful.
```

## ubuntu 22 riscv result

```shell
root@u22:~# ./test.sh
riscv64
Linux u22 6.8.0-71-generic #71~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Jul 29 11:14:09 UTC 2 riscv64 riscv64 riscv64 GNU/Linux
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
Cloning into 'rpds'...
remote: Enumerating objects: 1723, done.
remote: Counting objects: 100% (488/488), done.
remote: Compressing objects: 100% (121/121), done.
remote: Total 1723 (delta 427), reused 377 (delta 367), pack-reused 1235 (from 3)
Receiving objects: 100% (1723/1723), 364.20 KiB | 1.54 MiB/s, done.
Resolving deltas: 100% (1038/1038), done.
Branch 'feature/allow_riscv_package' set up to track remote branch 'feature/allow_riscv_package' from 'origin'.
Switched to a new branch 'feature/allow_riscv_package'
Python 3.10.12
Requirement already satisfied: pip in ./venv/lib/python3.10/site-packages (22.0.2)
Collecting pip
  Downloading pip-25.2-py3-none-any.whl (1.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 2.4 MB/s eta 0:00:00
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.0.2
    Uninstalling pip-22.0.2:
      Successfully uninstalled pip-22.0.2
Successfully installed pip-25.2
Looking in indexes: https://test.pypi.org/simple/
Collecting rpds-py==0.26.0
  Downloading https://test-files.pythonhosted.org/packages/e6/de/2d327dba331a82c4117e87736094d2bab04d692d4d17046c58911cc37a04/rpds_py-0.26.0-cp310-cp310-manylinux_2_31_riscv64.whl.metadata (4.2 kB)
Downloading https://test-files.pythonhosted.org/packages/e6/de/2d327dba331a82c4117e87736094d2bab04d692d4d17046c58911cc37a04/rpds_py-0.26.0-cp310-cp310-manylinux_2_31_riscv64.whl (401 kB)
Installing collected packages: rpds-py
Successfully installed rpds-py-0.26.0
[
  "tests-3.9",
  "tests-3.10",
  "tests-pypy3.10",
  "tests-3.11",
  "tests-pypy3.11",
  "tests-3.12",
  "tests-3.13",
  "tests-3.13t",
  "tests-3.14",
  "tests-3.14t",
  "audit",
  "build",
  "style",
  "typing",
  "docs(dirhtml)",
  "docs(doctest)",
  "docs(linkcheck)",
  "docs(man)",
  "docs(spelling)",
  "docs(style)"
]
nox > Running session tests-3.10
nox > Creating virtual environment (uv) using python3.10 in .nox/tests-3-10
nox > /root/.local/bin/uv pip install --config-settings build-args=--profile=dev --no-cache -r /root/rpds/tests/requirements.txt
nox > pytest --parallel-threads=10 /root/rpds/tests
================================================= test session starts ==================================================
platform linux -- Python 3.10.12, pytest-8.4.1, pluggy-1.6.0
rootdir: /root/rpds
configfile: pyproject.toml
plugins: run-parallel-0.4.4
collected 116 items
Collected 116 items to run in parallel

tests/test_hash_trie_map.py ···························································                          [ 50%]
tests/test_hash_trie_set.py ·····················                                                                [ 68%]
tests/test_list.py ···················                                                                           [ 85%]
tests/test_queue.py ·················                                                                            [100%]

********************************************** pytest-run-parallel report **********************************************
All tests were run in parallel! 🎉
================================================= 116 passed in 23.81s =================================================
nox > Session tests-3.10 was successful.
```


## other info
Co-authored-by: <nijincheng@iscas.ac.cn>；