### PR TITLE
Audit dependencies declared in `pyproject.toml`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -92,7 +92,7 @@ def audit(session):
     Audit dependencies for vulnerabilities.
     """
     session.install("pip-audit", ROOT)
-    session.run("python", "-m", "pip_audit")
+    session.run("python", "-m", "pip_audit", ROOT)
 
 
 @session(tags=["build"])


### PR DESCRIPTION
`nox -rs audit` is failing in otherwise.

See

- https://github.com/pypa/pip/issues/13607#issuecomment-3357278975.