### PR TITLE
Don’t depend on deprecated pyo3/generate-import-lib feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,4 @@ archery = "1.2.2"
 
 [dependencies.pyo3]
 version = "0.29.0"
-# To build extension for PyPy on Windows, "generate-import-lib" is needed:
-# https://github.com/PyO3/maturin-action/issues/267#issuecomment-2106844429
-features = ["extension-module", "generate-import-lib"]
+features = ["extension-module"]


### PR DESCRIPTION
Since PyO3 0.29, the `generate-import-lib` feature is deprecated and no longer has any effect; it is present only for backward-compatibility. See https://github.com/PyO3/pyo3/pull/5866.